### PR TITLE
fix: fix unnecessary errors returned

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# Deploying to AWS
+
+User has to have an active session to the banzai-dev-aws account, preferably targeted for the eu-west-1 region.
+
+### Deploy base infra CF template
+```
+aws cloudformation create-stack \                                                                                                                                                                                                                         ─╯
+  --stack-name reservr \
+  --template-body file://infra/infra.yaml --capabilities CAPABILITY_NAMED_IAM
+```
+or 
+```
+aws cloudformation update-stack \                                                                                                                                                                                                                         ─╯
+  --stack-name reservr \
+  --template-body file://infra/infra.yaml --capabilities CAPABILITY_NAMED_IAM
+```
+
+### Build and push docker image
+Image version should be bumped on deploy. Application lambda needs to be redeployed with a new image tag, otherwise it won't update.
+```
+make IMG=reservr-lambda:0.0.4  docker-build docker-push
+```
+
+### Deploy application layer
+```
+ aws cloudformation create-stack \                                                                                                                                                                                                                         ─╯
+   --stack-name reservr-app \
+  --template-body file://infra/lambda.yaml --capabilities CAPABILITY_NAMED_IAM
+```
+or
+```
+aws cloudformation update-stack \                                                                                                                                                                                                                         ─╯
+  --stack-name reservr-app \
+  --template-body file://infra/lambda.yaml --capabilities CAPABILITY_NAMED_IAM
+```
+
+### Run webhook maintainer script, using the Webex App bearer token
+Webex app token in stored in AWS secret store, and can be regenerated at developer.webex.com
+The API GW URL is the output of the reservr-app CF stack.
+
+```
+cd webhook
+go run main.go --token=<app token> --api-endpoint=<AWS API gateway URL>
+```

--- a/infra/lambda.yaml
+++ b/infra/lambda.yaml
@@ -38,7 +38,7 @@ Resources:
       FunctionName: reservr-lambda-function
       Code: 
         ImageUri: !Sub
-          - '${URI}:latest'
+          - '${URI}:0.0.3'
           - URI: !ImportValue LambdaUri
       PackageType: Image
       Role: !ImportValue ExecutorArn

--- a/infra/lambda.yaml
+++ b/infra/lambda.yaml
@@ -38,7 +38,7 @@ Resources:
       FunctionName: reservr-lambda-function
       Code: 
         ImageUri: !Sub
-          - '${URI}:0.0.3'
+          - '${URI}:0.0.4'
           - URI: !ImportValue LambdaUri
       PackageType: Image
       Role: !ImportValue ExecutorArn

--- a/internal/webex/realmessages.go
+++ b/internal/webex/realmessages.go
@@ -20,10 +20,16 @@ func New(client *webexteams.Client) MessagesClient {
 
 func (m *realMessagesClient) GetMessage(id string) (*webexteams.Message, *resty.Response, error) {
 	message, response, err := m.client.Messages.GetMessage(id)
-	return message, response, fmt.Errorf("failed to get message: %w", err)
+	if err != nil {
+		return message, response, fmt.Errorf("failed to get message: %w", err)
+	}
+	return message, response, nil
 }
 
 func (m *realMessagesClient) CreateMessage(messageCreateRequest *webexteams.MessageCreateRequest) (*webexteams.Message, *resty.Response, error) {
 	message, response, err := m.client.Messages.CreateMessage(messageCreateRequest)
-	return message, response, fmt.Errorf("failed to create message: %w", err)
+	if err != nil {
+		return message, response, fmt.Errorf("failed to create message: %w", err)
+	}
+	return message, response, nil
 }


### PR DESCRIPTION
Errors were returned even if no API error was present:
`failed to get message: %!w(<nil>)
`